### PR TITLE
Fixes issue #4

### DIFF
--- a/rellic/AST/GenerateAST.cpp
+++ b/rellic/AST/GenerateAST.cpp
@@ -354,6 +354,8 @@ bool GenerateAST::runOnModule(llvm::Module &module) {
 
   for (auto &func : module.functions()) {
     if (!func.isDeclaration()) {
+      // Clear the region statements from previous functions
+      region_stmts.clear();
       // Get dominator tree
       domtree = &getAnalysis<llvm::DominatorTreeWrapperPass>(func).getDomTree();
       // Get single-entry, single-exit regions

--- a/tests/issue_4.c
+++ b/tests/issue_4.c
@@ -1,0 +1,12 @@
+unsigned int foo(unsigned int a, unsigned int b) {
+	unsigned int sum = 0;
+	for (unsigned int i = 0; i != 42; i++) {
+		sum += a;
+		sum %= b;
+	}
+	return sum;
+}
+
+int main() {
+	return foo(1, 200);
+}


### PR DESCRIPTION
Function body ASTs were incorrectly generated when the input had
multiple function definitions. Previously generated function bodies
were assigned to subsequently generated functions. Which caused a
SIGSEGV in the later AST refinement passes.