### PR TITLE
Minor code improvements

### DIFF
--- a/rellic/AST/CondBasedRefine.cpp
+++ b/rellic/AST/CondBasedRefine.cpp
@@ -53,10 +53,10 @@ static void SplitClause(z3::expr expr, z3::expr_vector &clauses) {
 
 char CondBasedRefine::ID = 0;
 
-CondBasedRefine::CondBasedRefine(clang::CompilerInstance &ins,
+CondBasedRefine::CondBasedRefine(clang::ASTContext &ctx,
                                  rellic::IRToASTVisitor &ast_gen)
     : ModulePass(CondBasedRefine::ID),
-      ast_ctx(&ins.getASTContext()),
+      ast_ctx(&ctx),
       ast_gen(&ast_gen),
       z3_ctx(new z3::context()),
       z3_gen(new rellic::Z3ConvVisitor(ast_ctx, z3_ctx.get())) {}
@@ -184,8 +184,8 @@ bool CondBasedRefine::runOnModule(llvm::Module &module) {
   return changed;
 }
 
-llvm::ModulePass *createCondBasedRefinePass(clang::CompilerInstance &ins,
+llvm::ModulePass *createCondBasedRefinePass(clang::ASTContext &ctx,
                                             rellic::IRToASTVisitor &gen) {
-  return new CondBasedRefine(ins, gen);
+  return new CondBasedRefine(ctx, gen);
 }
 }  // namespace rellic

--- a/rellic/AST/CondBasedRefine.h
+++ b/rellic/AST/CondBasedRefine.h
@@ -48,14 +48,14 @@ class CondBasedRefine : public llvm::ModulePass,
  public:
   static char ID;
 
-  CondBasedRefine(clang::CompilerInstance &ins, rellic::IRToASTVisitor &ast_gen);
+  CondBasedRefine(clang::ASTContext &ctx, rellic::IRToASTVisitor &ast_gen);
 
   bool VisitCompoundStmt(clang::CompoundStmt *compound);
 
   bool runOnModule(llvm::Module &module) override;
 };
 
-llvm::ModulePass *createCondBasedRefinePass(clang::CompilerInstance &ins,
+llvm::ModulePass *createCondBasedRefinePass(clang::ASTContext &ctx,
                                             rellic::IRToASTVisitor &ast_gen);
 }  // namespace rellic
 

--- a/rellic/AST/DeadStmtElim.cpp
+++ b/rellic/AST/DeadStmtElim.cpp
@@ -24,10 +24,10 @@ namespace rellic {
 
 char DeadStmtElim::ID = 0;
 
-DeadStmtElim::DeadStmtElim(clang::CompilerInstance &ins,
+DeadStmtElim::DeadStmtElim(clang::ASTContext &ctx,
                            rellic::IRToASTVisitor &ast_gen)
     : ModulePass(DeadStmtElim::ID),
-      ast_ctx(&ins.getASTContext()),
+      ast_ctx(&ctx),
       ast_gen(&ast_gen) {}
 
 bool DeadStmtElim::VisitIfStmt(clang::IfStmt *ifstmt) {
@@ -73,8 +73,8 @@ bool DeadStmtElim::runOnModule(llvm::Module &module) {
   return changed;
 }
 
-llvm::ModulePass *createDeadStmtElimPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createDeadStmtElimPass(clang::ASTContext &ctx,
                                          rellic::IRToASTVisitor &gen) {
-  return new DeadStmtElim(ins, gen);
+  return new DeadStmtElim(ctx, gen);
 }
 }  // namespace rellic

--- a/rellic/AST/DeadStmtElim.h
+++ b/rellic/AST/DeadStmtElim.h
@@ -34,7 +34,7 @@ class DeadStmtElim : public llvm::ModulePass,
  public:
   static char ID;
 
-  DeadStmtElim(clang::CompilerInstance &ins, rellic::IRToASTVisitor &ast_gen);
+  DeadStmtElim(clang::ASTContext &ctx, rellic::IRToASTVisitor &ast_gen);
 
   bool VisitIfStmt(clang::IfStmt *ifstmt);
   bool VisitCompoundStmt(clang::CompoundStmt *compound);
@@ -42,7 +42,7 @@ class DeadStmtElim : public llvm::ModulePass,
   bool runOnModule(llvm::Module &module) override;
 };
 
-llvm::ModulePass *createDeadStmtElimPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createDeadStmtElimPass(clang::ASTContext &ctx,
                                          rellic::IRToASTVisitor &ast_gen);
 }  // namespace rellic
 

--- a/rellic/AST/GenerateAST.cpp
+++ b/rellic/AST/GenerateAST.cpp
@@ -331,11 +331,8 @@ clang::CompoundStmt *GenerateAST::StructureRegion(llvm::Region *region) {
 
 char GenerateAST::ID = 0;
 
-GenerateAST::GenerateAST(clang::CompilerInstance &ins,
-                         rellic::IRToASTVisitor &ast_gen)
-    : ModulePass(GenerateAST::ID),
-      ast_ctx(&ins.getASTContext()),
-      ast_gen(&ast_gen) {}
+GenerateAST::GenerateAST(clang::ASTContext &ctx, rellic::IRToASTVisitor &gen)
+    : ModulePass(GenerateAST::ID), ast_ctx(&ctx), ast_gen(&gen) {}
 
 void GenerateAST::getAnalysisUsage(llvm::AnalysisUsage &usage) const {
   usage.addRequired<llvm::DominatorTreeWrapperPass>();
@@ -385,9 +382,9 @@ bool GenerateAST::runOnModule(llvm::Module &module) {
   return true;
 }
 
-llvm::ModulePass *createGenerateASTPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createGenerateASTPass(clang::ASTContext &ctx,
                                         rellic::IRToASTVisitor &gen) {
-  return new GenerateAST(ins, gen);
+  return new GenerateAST(ctx, gen);
 }
 
 }  // namespace rellic

--- a/rellic/AST/GenerateAST.h
+++ b/rellic/AST/GenerateAST.h
@@ -58,14 +58,14 @@ class GenerateAST : public llvm::ModulePass {
  public:
   static char ID;
 
-  GenerateAST(clang::CompilerInstance &ins, rellic::IRToASTVisitor &ast_gen);
+  GenerateAST(clang::ASTContext &ctx, rellic::IRToASTVisitor &gen);
 
   void getAnalysisUsage(llvm::AnalysisUsage &usage) const override;
   bool runOnModule(llvm::Module &module) override;
 };
 
-llvm::ModulePass *createGenerateASTPass(clang::CompilerInstance &ins,
-                                        rellic::IRToASTVisitor &ast_gen);
+llvm::ModulePass *createGenerateASTPass(clang::ASTContext &ctx,
+                                        rellic::IRToASTVisitor &gen);
 }  // namespace rellic
 
 namespace llvm {

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -135,8 +135,7 @@ static clang::VarDecl *CreateVarDecl(clang::ASTContext &ast_ctx,
 
 }  // namespace
 
-IRToASTVisitor::IRToASTVisitor(clang::CompilerInstance &ins)
-    : cc_ins(&ins), ast_ctx(cc_ins->getASTContext()) {}
+IRToASTVisitor::IRToASTVisitor(clang::ASTContext &ctx) : ast_ctx(ctx) {}
 
 clang::FunctionDecl *IRToASTVisitor::GetFunctionDecl(llvm::Instruction *inst) {
   return llvm::dyn_cast<clang::FunctionDecl>(

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -29,7 +29,6 @@ namespace rellic {
 
 class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
  private:
-  clang::CompilerInstance *cc_ins;
   clang::ASTContext &ast_ctx;
 
   std::unordered_map<llvm::Value *, clang::Decl *> decls;
@@ -39,7 +38,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   clang::Expr *GetOperandExpr(clang::DeclContext *decl_ctx, llvm::Value *val);
 
  public:
-  IRToASTVisitor(clang::CompilerInstance &ins);
+  IRToASTVisitor(clang::ASTContext &ctx);
   
   clang::Stmt *GetOrCreateStmt(llvm::Value *val);
   clang::Decl *GetOrCreateDecl(llvm::Value *val);

--- a/rellic/AST/LoopRefine.cpp
+++ b/rellic/AST/LoopRefine.cpp
@@ -293,10 +293,10 @@ class CondToSeqNegRule
 
 char LoopRefine::ID = 0;
 
-LoopRefine::LoopRefine(clang::CompilerInstance &ins,
+LoopRefine::LoopRefine(clang::ASTContext &ctx,
                        rellic::IRToASTVisitor &ast_gen)
     : ModulePass(LoopRefine::ID),
-      ast_ctx(&ins.getASTContext()),
+      ast_ctx(&ctx),
       ast_gen(&ast_gen) {}
 
 bool LoopRefine::VisitWhileStmt(clang::WhileStmt *loop) {
@@ -352,8 +352,8 @@ bool LoopRefine::runOnModule(llvm::Module &module) {
   return changed;
 }
 
-llvm::ModulePass *createLoopRefinePass(clang::CompilerInstance &ins,
+llvm::ModulePass *createLoopRefinePass(clang::ASTContext &ctx,
                                        rellic::IRToASTVisitor &gen) {
-  return new LoopRefine(ins, gen);
+  return new LoopRefine(ctx, gen);
 }
 }  // namespace rellic

--- a/rellic/AST/LoopRefine.h
+++ b/rellic/AST/LoopRefine.h
@@ -34,14 +34,14 @@ class LoopRefine : public llvm::ModulePass,
  public:
   static char ID;
 
-  LoopRefine(clang::CompilerInstance &ins, rellic::IRToASTVisitor &ast_gen);
+  LoopRefine(clang::ASTContext &ctx, rellic::IRToASTVisitor &ast_gen);
 
   bool VisitWhileStmt(clang::WhileStmt *loop);
 
   bool runOnModule(llvm::Module &module) override;
 };
 
-llvm::ModulePass *createLoopRefinePass(clang::CompilerInstance &ins,
+llvm::ModulePass *createLoopRefinePass(clang::ASTContext &ctx,
                                        rellic::IRToASTVisitor &ast_gen);
 }  // namespace rellic
 

--- a/rellic/AST/NestedCondProp.cpp
+++ b/rellic/AST/NestedCondProp.cpp
@@ -39,10 +39,10 @@ static std::vector<clang::IfStmt *> GetIfStmts(clang::CompoundStmt *compound) {
 
 char NestedCondProp::ID = 0;
 
-NestedCondProp::NestedCondProp(clang::CompilerInstance &ins,
+NestedCondProp::NestedCondProp(clang::ASTContext &ctx,
                                rellic::IRToASTVisitor &ast_gen)
     : ModulePass(NestedCondProp::ID),
-      ast_ctx(&ins.getASTContext()),
+      ast_ctx(&ctx),
       ast_gen(&ast_gen),
       z3_ctx(new z3::context()),
       z3_gen(new rellic::Z3ConvVisitor(ast_ctx, z3_ctx.get())) {}
@@ -100,8 +100,8 @@ bool NestedCondProp::runOnModule(llvm::Module &module) {
   return changed;
 }
 
-llvm::ModulePass *createNestedCondPropPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createNestedCondPropPass(clang::ASTContext &ctx,
                                            rellic::IRToASTVisitor &gen) {
-  return new NestedCondProp(ins, gen);
+  return new NestedCondProp(ctx, gen);
 }
 }  // namespace rellic

--- a/rellic/AST/NestedCondProp.h
+++ b/rellic/AST/NestedCondProp.h
@@ -44,14 +44,14 @@ class NestedCondProp : public llvm::ModulePass,
 
   bool shouldTraversePostOrder() { return false; }
 
-  NestedCondProp(clang::CompilerInstance &ins, rellic::IRToASTVisitor &ast_gen);
+  NestedCondProp(clang::ASTContext &ctx, rellic::IRToASTVisitor &ast_gen);
 
   bool VisitIfStmt(clang::IfStmt *stmt);
 
   bool runOnModule(llvm::Module &module) override;
 };
 
-llvm::ModulePass *createNestedCondPropPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createNestedCondPropPass(clang::ASTContext &ctx,
                                            rellic::IRToASTVisitor &ast_gen);
 }  // namespace rellic
 

--- a/rellic/AST/NestedScopeCombiner.cpp
+++ b/rellic/AST/NestedScopeCombiner.cpp
@@ -24,10 +24,10 @@ namespace rellic {
 
 char NestedScopeCombiner::ID = 0;
 
-NestedScopeCombiner::NestedScopeCombiner(clang::CompilerInstance &ins,
+NestedScopeCombiner::NestedScopeCombiner(clang::ASTContext &ctx,
                                          rellic::IRToASTVisitor &ast_gen)
     : ModulePass(NestedScopeCombiner::ID),
-      ast_ctx(&ins.getASTContext()),
+      ast_ctx(&ctx),
       ast_gen(&ast_gen) {}
 
 bool NestedScopeCombiner::VisitIfStmt(clang::IfStmt *ifstmt) {
@@ -69,8 +69,8 @@ bool NestedScopeCombiner::runOnModule(llvm::Module &module) {
   return changed;
 }
 
-llvm::ModulePass *createNestedScopeCombinerPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createNestedScopeCombinerPass(clang::ASTContext &ctx,
                                                 rellic::IRToASTVisitor &gen) {
-  return new NestedScopeCombiner(ins, gen);
+  return new NestedScopeCombiner(ctx, gen);
 }
 }  // namespace rellic

--- a/rellic/AST/NestedScopeCombiner.h
+++ b/rellic/AST/NestedScopeCombiner.h
@@ -34,7 +34,7 @@ class NestedScopeCombiner : public llvm::ModulePass,
  public:
   static char ID;
 
-  NestedScopeCombiner(clang::CompilerInstance &ins,
+  NestedScopeCombiner(clang::ASTContext &ctx,
                       rellic::IRToASTVisitor &ast_gen);
 
   bool VisitIfStmt(clang::IfStmt *ifstmt);
@@ -43,7 +43,7 @@ class NestedScopeCombiner : public llvm::ModulePass,
   bool runOnModule(llvm::Module &module) override;
 };
 
-llvm::ModulePass *createNestedScopeCombinerPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createNestedScopeCombinerPass(clang::ASTContext &ctx,
                                                 rellic::IRToASTVisitor &ast_gen);
 }  // namespace rellic
 

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -44,6 +44,18 @@ static clang::Expr *CreateBoolBinOp(clang::ASTContext &ctx,
 
 }  // namespace
 
+void InitCompilerInstance(clang::CompilerInstance &ins,
+                          std::string target_triple) {
+  ins.createDiagnostics();
+  ins.getTargetOpts().Triple = target_triple;
+  ins.setTarget(clang::TargetInfo::CreateTargetInfo(
+      ins.getDiagnostics(), ins.getInvocation().TargetOpts));
+  ins.createFileManager();
+  ins.createSourceManager(ins.getFileManager());
+  ins.createPreprocessor(clang::TU_Complete);
+  ins.createASTContext();
+}
+
 bool ReplaceChildren(clang::Stmt *stmt, StmtMap &repl_map) {
   auto change = false;
   for (auto c_it = stmt->child_begin(); c_it != stmt->child_end(); ++c_it) {

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -19,12 +19,17 @@
 
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Expr.h>
+#include <clang/Basic/TargetInfo.h>
+#include <clang/Frontend/CompilerInstance.h>
 
 #include <unordered_map>
 
 namespace rellic {
 
 using StmtMap = std::unordered_map<clang::Stmt *, clang::Stmt *>;
+
+void InitCompilerInstance(clang::CompilerInstance &ins,
+                          std::string target_triple);
 
 bool ReplaceChildren(clang::Stmt *stmt, StmtMap &repl_map);
 

--- a/rellic/AST/Z3CondSimplify.cpp
+++ b/rellic/AST/Z3CondSimplify.cpp
@@ -23,10 +23,10 @@ namespace rellic {
 
 char Z3CondSimplify::ID = 0;
 
-Z3CondSimplify::Z3CondSimplify(clang::CompilerInstance &ins,
+Z3CondSimplify::Z3CondSimplify(clang::ASTContext &ctx,
                                rellic::IRToASTVisitor &ast_gen)
     : ModulePass(Z3CondSimplify::ID),
-      ast_ctx(&ins.getASTContext()),
+      ast_ctx(&ctx),
       ast_gen(&ast_gen),
       z3_ctx(new z3::context()),
       z3_gen(new rellic::Z3ConvVisitor(ast_ctx, z3_ctx.get())),
@@ -65,8 +65,8 @@ bool Z3CondSimplify::runOnModule(llvm::Module &module) {
   return changed;
 }
 
-llvm::ModulePass *createZ3CondSimplifyPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createZ3CondSimplifyPass(clang::ASTContext &ctx,
                                            rellic::IRToASTVisitor &gen) {
-  return new Z3CondSimplify(ins, gen);
+  return new Z3CondSimplify(ctx, gen);
 }
 }  // namespace rellic

--- a/rellic/AST/Z3CondSimplify.h
+++ b/rellic/AST/Z3CondSimplify.h
@@ -42,7 +42,7 @@ class Z3CondSimplify : public llvm::ModulePass,
  public:
   static char ID;
 
-  Z3CondSimplify(clang::CompilerInstance &ins, rellic::IRToASTVisitor &ast_gen);
+  Z3CondSimplify(clang::ASTContext &ctx, rellic::IRToASTVisitor &ast_gen);
 
   z3::context &GetZ3Context() { return *z3_ctx; }
   
@@ -55,7 +55,7 @@ class Z3CondSimplify : public llvm::ModulePass,
   bool runOnModule(llvm::Module &module) override;
 };
 
-llvm::ModulePass *createZ3CondSimplifyPass(clang::CompilerInstance &ins,
+llvm::ModulePass *createZ3CondSimplifyPass(clang::ASTContext &ctx,
                                            rellic::IRToASTVisitor &gen);
 }  // namespace rellic
 

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -61,44 +61,24 @@ static void InitOptPasses(void) {
   initializeAnalysis(pr);
 }
 
-static bool InitCompilerInstance(llvm::Module& module,
-                                 clang::CompilerInstance& ins) {
-  auto inv = std::make_shared<clang::CompilerInvocation>();
-
-  const char* tmp[] = {""};
-  ins.setDiagnostics(ins.createDiagnostics(new clang::DiagnosticOptions).get());
-  clang::CompilerInvocation::CreateFromArgs(*inv, tmp, tmp,
-                                            ins.getDiagnostics());
-
-  inv->getTargetOpts().Triple = module.getTargetTriple();
-  ins.setInvocation(inv);
-  ins.setTarget(clang::TargetInfo::CreateTargetInfo(
-      ins.getDiagnostics(), ins.getInvocation().TargetOpts));
-
-  ins.createFileManager();
-  ins.createSourceManager(ins.getFileManager());
-  ins.createPreprocessor(clang::TU_Complete);
-  ins.createASTContext();
-
-  return true;
-}
-
 static bool GeneratePseudocode(llvm::Module& module,
                                llvm::raw_ostream& output) {
   InitOptPasses();
 
   clang::CompilerInstance ins;
-  InitCompilerInstance(module, ins);
+  rellic::InitCompilerInstance(ins, module.getTargetTriple());
+  
+  auto& ast_ctx = ins.getASTContext();
 
-  rellic::IRToASTVisitor gen(ins);
+  rellic::IRToASTVisitor gen(ast_ctx);
 
   llvm::legacy::PassManager ast;
-  ast.add(rellic::createGenerateASTPass(ins, gen));
-  ast.add(rellic::createDeadStmtElimPass(ins, gen));
+  ast.add(rellic::createGenerateASTPass(ast_ctx, gen));
+  ast.add(rellic::createDeadStmtElimPass(ast_ctx, gen));
   ast.run(module);
 
   // Simplifier to use during condition-based refinement
-  auto cbr_simplifier = new rellic::Z3CondSimplify(ins, gen);
+  auto cbr_simplifier = new rellic::Z3CondSimplify(ast_ctx, gen);
   cbr_simplifier->SetZ3Simplifier(
       // Simplify boolean structure with AIGs
       z3::tactic(cbr_simplifier->GetZ3Context(), "aig") &
@@ -107,20 +87,20 @@ static bool GeneratePseudocode(llvm::Module& module,
 
   llvm::legacy::PassManager cbr;
   cbr.add(cbr_simplifier);
-  cbr.add(rellic::createNestedCondPropPass(ins, gen));
-  cbr.add(rellic::createNestedScopeCombinerPass(ins, gen));
-  cbr.add(rellic::createCondBasedRefinePass(ins, gen));
+  cbr.add(rellic::createNestedCondPropPass(ast_ctx, gen));
+  cbr.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
+  cbr.add(rellic::createCondBasedRefinePass(ast_ctx, gen));
   while (cbr.run(module))
     ;
 
   llvm::legacy::PassManager loop;
-  loop.add(rellic::createLoopRefinePass(ins, gen));
-  loop.add(rellic::createNestedScopeCombinerPass(ins, gen));
+  loop.add(rellic::createLoopRefinePass(ast_ctx, gen));
+  loop.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
   while (loop.run(module))
     ;
 
   // Simplifier to use during final refinement
-  auto fin_simplifier = new rellic::Z3CondSimplify(ins, gen);
+  auto fin_simplifier = new rellic::Z3CondSimplify(ast_ctx, gen);
   fin_simplifier->SetZ3Simplifier(
       // Simplify boolean structure with AIGs
       z3::tactic(fin_simplifier->GetZ3Context(), "aig") &
@@ -133,12 +113,12 @@ static bool GeneratePseudocode(llvm::Module& module,
 
   llvm::legacy::PassManager fin;
   fin.add(fin_simplifier);
-  fin.add(rellic::createNestedCondPropPass(ins, gen));
-  fin.add(rellic::createNestedScopeCombinerPass(ins, gen));
-  fin.add(rellic::createDeadStmtElimPass(ins, gen));
+  fin.add(rellic::createNestedCondPropPass(ast_ctx, gen));
+  fin.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
+  fin.add(rellic::createDeadStmtElimPass(ast_ctx, gen));
   fin.run(module);
 
-  ins.getASTContext().getTranslationUnitDecl()->print(output);
+  ast_ctx.getTranslationUnitDecl()->print(output);
 
   return true;
 }


### PR DESCRIPTION
Replaces clang::CompilerInstance with clang::ASTContext in AST visitor constructors.