### PR TITLE
Handling of reference and pointer types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you are experiencing undocumented problems with Rellic then ask for help in t
 
 ## Supported Platforms
 
-Rellic is supported on Linux platforms and has been tested on Ubuntu 18.04.
+Rellic is supported on Linux platforms and has been tested on Ubuntu 16.04 and 18.04.
 
 ## Dependencies
 

--- a/rellic/AST/CXXToCDecl.h
+++ b/rellic/AST/CXXToCDecl.h
@@ -35,22 +35,32 @@ class CXXToCDeclVisitor : public clang::RecursiveASTVisitor<CXXToCDeclVisitor> {
 
   std::string GetMangledName(clang::NamedDecl *decl);
   clang::QualType GetAsCType(clang::QualType type);
-  
 
  public:
   CXXToCDeclVisitor(clang::ASTContext &ctx);
 
   bool shouldVisitTemplateInstantiations() { return true; }
 
-  bool TraverseFunctionDecl(clang::FunctionDecl *func);
+  bool TraverseFunctionTemplateDecl(clang::FunctionTemplateDecl *decl) {
+    // Ignore function templates
+    return true;
+  }
+
+  bool TraverseClassTemplateDecl(clang::ClassTemplateDecl *decl) {
+    // Only process class template specializations
+    for (auto spec : decl->specializations()) {
+      TraverseDecl(spec);
+    }
+    return true;
+  }
+
   bool VisitFunctionDecl(clang::FunctionDecl *func);
-  
+
   bool VisitFieldDecl(clang::FieldDecl *field);
   bool VisitRecordDecl(clang::RecordDecl *record);
-    
-  bool TraverseCXXRecordDecl(clang::CXXRecordDecl *cls);
+
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *cls);
-  
+
   bool VisitCXXMethodDecl(clang::CXXMethodDecl *method);
 };
 

--- a/rellic/AST/CXXToCDecl.h
+++ b/rellic/AST/CXXToCDecl.h
@@ -55,13 +55,10 @@ class CXXToCDeclVisitor : public clang::RecursiveASTVisitor<CXXToCDeclVisitor> {
   }
 
   bool VisitFunctionDecl(clang::FunctionDecl *func);
-
-  bool VisitFieldDecl(clang::FieldDecl *field);
-  bool VisitRecordDecl(clang::RecordDecl *record);
-
-  bool VisitCXXRecordDecl(clang::CXXRecordDecl *cls);
-
   bool VisitCXXMethodDecl(clang::CXXMethodDecl *method);
+  bool VisitRecordDecl(clang::RecordDecl *record);
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *cls);
+  bool VisitFieldDecl(clang::FieldDecl *field);
 };
 
 }  // namespace rellic

--- a/rellic/AST/CXXToCDecl.h
+++ b/rellic/AST/CXXToCDecl.h
@@ -31,16 +31,17 @@ class CXXToCDeclVisitor : public clang::RecursiveASTVisitor<CXXToCDeclVisitor> {
   std::unordered_map<clang::Decl *, clang::Decl *> c_decls;
 
   std::string GetMangledName(clang::NamedDecl *decl);
-
-  clang::RecordDecl *GetOrCreateStructDecl(clang::CXXRecordDecl *cls);
-  clang::QualType GetAsStructType(clang::QualType type);
+  clang::QualType GetAsCType(clang::QualType type);
+  
 
  public:
   CXXToCDeclVisitor(clang::ASTContext &ctx);
 
   bool shouldVisitTemplateInstantiations() { return true; }
-  bool shouldTraversePostOrder() { return true; }
 
+  bool VisitFieldDecl(clang::FieldDecl *field);
+  bool VisitRecordDecl(clang::RecordDecl *record);
+  bool VisitParmVarDecl(clang::ParmVarDecl *param);
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *cls);
   bool VisitCXXMethodDecl(clang::CXXMethodDecl *method);
 };

--- a/rellic/AST/CXXToCDecl.h
+++ b/rellic/AST/CXXToCDecl.h
@@ -33,6 +33,7 @@ class CXXToCDeclVisitor : public clang::RecursiveASTVisitor<CXXToCDeclVisitor> {
   std::string GetMangledName(clang::NamedDecl *decl);
 
   clang::RecordDecl *GetOrCreateStructDecl(clang::CXXRecordDecl *cls);
+  clang::QualType GetAsStructType(clang::QualType type);
 
  public:
   CXXToCDeclVisitor(clang::ASTContext &ctx);

--- a/rellic/AST/CXXToCDecl.h
+++ b/rellic/AST/CXXToCDecl.h
@@ -17,6 +17,9 @@
 #ifndef RELLIC_AST_CXXTOCDECL_H_
 #define RELLIC_AST_CXXTOCDECL_H_
 
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
 #include <clang/AST/RecursiveASTVisitor.h>
 
 #include <unordered_map>
@@ -39,10 +42,15 @@ class CXXToCDeclVisitor : public clang::RecursiveASTVisitor<CXXToCDeclVisitor> {
 
   bool shouldVisitTemplateInstantiations() { return true; }
 
+  bool TraverseFunctionDecl(clang::FunctionDecl *func);
+  bool VisitFunctionDecl(clang::FunctionDecl *func);
+  
   bool VisitFieldDecl(clang::FieldDecl *field);
   bool VisitRecordDecl(clang::RecordDecl *record);
-  bool VisitParmVarDecl(clang::ParmVarDecl *param);
+    
+  bool TraverseCXXRecordDecl(clang::CXXRecordDecl *cls);
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *cls);
+  
   bool VisitCXXMethodDecl(clang::CXXMethodDecl *method);
 };
 

--- a/tools/headergen/HeaderGen.cpp
+++ b/tools/headergen/HeaderGen.cpp
@@ -106,6 +106,7 @@ int main(int argc, char* argv[]) {
   rellic::InitCompilerInstance(c_ins);
   auto& c_ast_ctx = c_ins.getASTContext();
   rellic::CXXToCDeclVisitor visitor(c_ast_ctx);
+  // cxx_ast_unit->getASTContext().getTranslationUnitDecl()->dump();
   visitor.TraverseDecl(cxx_ast_unit->getASTContext().getTranslationUnitDecl());
   // Print output
   c_ast_ctx.getTranslationUnitDecl()->print(output);


### PR DESCRIPTION
This PR adds handling of pointer and reference types. Also refactors `CXXToCDeclVisitor` to work in pre-order (which seems to be more in line of how clang intends the AST to be created) and splits it's visitor methods into more manageable chunks.

Closes #18 

Previously:
```C++
struct _ZTSSt4pairIiiE {
    int first;
    int second;
};
void _ZNSt4pairIiiEC1Ev(struct _ZTSSt4pairIiiE *this);
void _ZNSt4pairIiiEC1ERKiS2_(struct _ZTSSt4pairIiiE *this, const int &__a, const int &__b);
struct _ZTS7MyClass {
    struct _ZTSSt4pairIiiE my_pair;
};
struct _ZTSSt4pairIiiE _ZN7MyClass8MyMethodESt4pairIiiE(struct _ZTS7MyClass *this, struct _ZTSSt4pairIiiE pair);
```
Currently:
```C++
struct _ZTSSt4pairIiiE {
    int first;
    int second;
};
void _ZNSt4pairIiiEC1Ev(struct _ZTSSt4pairIiiE *this);
void _ZNSt4pairIiiEC1ERKiS2_(struct _ZTSSt4pairIiiE *this, const int * _Nonnull __a, const int * _Nonnull __b);
struct _ZTS7MyClass {
    struct _ZTSSt4pairIiiE my_pair;
};
struct _ZTSSt4pairIiiE _ZN7MyClass8MyMethodESt4pairIiiE(struct _ZTS7MyClass *this, struct _ZTSSt4pairIiiE pair);
```