### PR TITLE
Translation and simplification of aggregate LLVM types

### DIFF
--- a/rellic/AST/ExprCombine.h
+++ b/rellic/AST/ExprCombine.h
@@ -37,6 +37,7 @@ class ExprCombine : public llvm::ModulePass,
 
   bool VisitUnaryOperator(clang::UnaryOperator *op);
   bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *expr);
+  bool VisitMemberExpr(clang::MemberExpr *expr);
   bool VisitParenExpr(clang::ParenExpr *paren);
 
   bool runOnModule(llvm::Module &module) override;

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -104,7 +104,7 @@ clang::QualType IRToASTVisitor::GetQualType(llvm::Type *type) {
         tudecl->addDecl(sdecl);
       } else {
         sdecl = clang::cast<clang::RecordDecl>(decl);
-      }     
+      }
       result = ast_ctx.getRecordType(sdecl);
     } break;
 
@@ -125,8 +125,7 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(clang::DeclContext *decl_ctx,
 
   auto CreateInitListLiteral = [this, &decl_ctx, &constant] {
     std::vector<clang::Expr *> init_exprs;
-    for (auto i = 0U; i < constant->getNumOperands(); ++i) {
-      auto elm = constant->getAggregateElement(i);
+    for (auto i = 0U; auto elm = constant->getAggregateElement(i); ++i) {
       init_exprs.push_back(CreateLiteralExpr(decl_ctx, elm));
     }
     return CreateInitListExpr(ast_ctx, init_exprs);

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// #define GOOGLE_STRIP_LOG 1
+#define GOOGLE_STRIP_LOG 1
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
@@ -150,6 +150,12 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(clang::DeclContext *decl_ctx,
       result = CreateIntegerLiteral(ast_ctx, val, c_type);
     } break;
 
+    case llvm::Type::PointerTyID: {
+      CHECK(llvm::isa<llvm::ConstantPointerNull>(constant))
+          << "Non-null pointer constant?";
+      result = CreateNullPointerExpr(ast_ctx);
+    } break;
+
     case llvm::Type::ArrayTyID: {
       auto arr = llvm::cast<llvm::ConstantDataArray>(constant);
       result = arr->isString()
@@ -160,6 +166,11 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(clang::DeclContext *decl_ctx,
     case llvm::Type::StructTyID: {
       result = CreateInitListLiteral();
     } break;
+
+    case llvm::Type::VectorTyID: {
+      LOG(FATAL) << "Unimplemented VectorTyID";
+    } break;
+
 
     default:
       LOG(FATAL) << "Unknown LLVM constant type";

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -31,15 +31,23 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
  private:
   clang::ASTContext &ast_ctx;
 
-  std::unordered_map<llvm::Value *, clang::Decl *> decls;
+  std::unordered_map<llvm::Type *, clang::TypeDecl *> type_decls;
+  std::unordered_map<llvm::Value *, clang::ValueDecl *> value_decls;
   std::unordered_map<llvm::Value *, clang::Stmt *> stmts;
 
   clang::FunctionDecl *GetFunctionDecl(llvm::Instruction *inst);
   clang::Expr *GetOperandExpr(clang::DeclContext *decl_ctx, llvm::Value *val);
+  clang::QualType GetQualType(llvm::Type *type);
+
+  clang::Expr *CreateLiteralExpr(clang::DeclContext *decl_ctx,
+                                 llvm::ConstantData *cdata);
+
+  clang::VarDecl *CreateVarDecl(clang::DeclContext *decl_ctx, llvm::Type *type,
+                                std::string name);
 
  public:
   IRToASTVisitor(clang::ASTContext &ctx);
-  
+
   clang::Stmt *GetOrCreateStmt(llvm::Value *val);
   clang::Decl *GetOrCreateDecl(llvm::Value *val);
 

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -40,7 +40,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   clang::QualType GetQualType(llvm::Type *type);
 
   clang::Expr *CreateLiteralExpr(clang::DeclContext *decl_ctx,
-                                 llvm::ConstantData *cdata);
+                                 llvm::Constant *constant);
 
   clang::VarDecl *CreateVarDecl(clang::DeclContext *decl_ctx, llvm::Type *type,
                                 std::string name);

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -153,10 +153,28 @@ clang::RecordDecl *CreateStructDecl(clang::ASTContext &ctx,
                                    clang::SourceLocation(), id, prev_decl);
 }
 
+clang::Expr *CreateFloatingLiteral(clang::ASTContext &ctx, llvm::APFloat &val,
+                                   clang::QualType type) {
+  return clang::FloatingLiteral::Create(ctx, val, /*isexact=*/true, type,
+                                        clang::SourceLocation());
+}
+
+clang::Expr *CreateIntegerLiteral(clang::ASTContext &ctx, llvm::APInt &val,
+                                  clang::QualType type) {
+  return clang::IntegerLiteral::Create(ctx, val, type, clang::SourceLocation());
+}
+
 clang::Expr *CreateTrueExpr(clang::ASTContext &ctx) {
-  return clang::IntegerLiteral::Create(
-      ctx, llvm::APInt(ctx.getIntWidth(ctx.UnsignedIntTy), 1),
-      ctx.UnsignedIntTy, clang::SourceLocation());
+  auto type = ctx.UnsignedIntTy;
+  auto val = llvm::APInt(ctx.getIntWidth(type), 1);
+  return CreateIntegerLiteral(ctx, val, type);
+}
+
+clang::Expr *CreateStringLiteral(clang::ASTContext &ctx, std::string val,
+                                 clang::QualType type) {
+  return clang::StringLiteral::Create(
+      ctx, val, clang::StringLiteral::StringKind::Ascii,
+      /*Pascal=*/false, type, clang::SourceLocation());
 }
 
 clang::Expr *CreateInitListExpr(clang::ASTContext &ctx,

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -190,4 +190,12 @@ clang::Expr *CreateArraySubscriptExpr(clang::ASTContext &ctx, clang::Expr *base,
                                 clang::OK_Ordinary, clang::SourceLocation());
 }
 
+clang::Expr *CreateMemberExpr(clang::ASTContext &ctx, clang::Expr *base,
+                              clang::ValueDecl *member, clang::QualType type,
+                              bool is_arrow) {
+  return new (ctx) clang::MemberExpr(base, is_arrow, clang::SourceLocation(),
+                                     member, clang::SourceLocation(), type,
+                                     clang::VK_RValue, clang::OK_Ordinary);
+}
+
 }  // namespace rellic

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -198,4 +198,20 @@ clang::Expr *CreateMemberExpr(clang::ASTContext &ctx, clang::Expr *base,
                                      clang::VK_RValue, clang::OK_Ordinary);
 }
 
+clang::Expr *CreateCStyleCastExpr(clang::ASTContext &ctx, clang::QualType type,
+                                  clang::CastKind cast, clang::Expr *op) {
+  return clang::CStyleCastExpr::Create(
+      ctx, type, clang::VK_RValue, cast, op, nullptr,
+      ctx.getTrivialTypeSourceInfo(type), clang::SourceLocation(),
+      clang::SourceLocation());
+}
+
+clang::Expr *CreateNullPointerExpr(clang::ASTContext &ctx) {
+  auto type = ctx.UnsignedIntTy;
+  auto val = llvm::APInt::getNullValue(ctx.getTypeSize(type));
+  auto zero = CreateIntegerLiteral(ctx, val, type);
+  return CreateCStyleCastExpr(ctx, ctx.getPointerType(ctx.VoidTy),
+                              clang::CastKind::CK_NullToPointer, zero);
+}
+
 }  // namespace rellic

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -82,7 +82,16 @@ clang::RecordDecl *CreateStructDecl(clang::ASTContext &ctx,
                                     clang::IdentifierInfo *id,
                                     clang::RecordDecl *prev_decl = nullptr);
 
+clang::Expr *CreateFloatingLiteral(clang::ASTContext &ctx, llvm::APFloat &val,
+                                   clang::QualType type);
+
+clang::Expr *CreateIntegerLiteral(clang::ASTContext &ctx, llvm::APInt &val,
+                                  clang::QualType type);
+
 clang::Expr *CreateTrueExpr(clang::ASTContext &ctx);
+
+clang::Expr *CreateStringLiteral(clang::ASTContext &ctx, std::string val,
+                                 clang::QualType);
 
 clang::Expr *CreateInitListExpr(clang::ASTContext &ctx,
                                 std::vector<clang::Expr *> &exprs);

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -99,4 +99,8 @@ clang::Expr *CreateInitListExpr(clang::ASTContext &ctx,
 clang::Expr *CreateArraySubscriptExpr(clang::ASTContext &ctx, clang::Expr *base,
                                       clang::Expr *idx, clang::QualType type);
 
+clang::Expr *CreateMemberExpr(clang::ASTContext &ctx, clang::Expr *base,
+                              clang::ValueDecl *member, clang::QualType type,
+                              bool is_arrow = false);
+
 }  // namespace rellic

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -103,4 +103,6 @@ clang::Expr *CreateMemberExpr(clang::ASTContext &ctx, clang::Expr *base,
                               clang::ValueDecl *member, clang::QualType type,
                               bool is_arrow = false);
 
+clang::Expr *CreateNullPointerExpr(clang::ASTContext &ctx);
+
 }  // namespace rellic

--- a/rellic/AST/Z3ConvVisitor.cpp
+++ b/rellic/AST/Z3ConvVisitor.cpp
@@ -125,14 +125,12 @@ static clang::Expr *CreateLiteralExpr(clang::ASTContext &ast_ctx,
       type = ast_ctx.UnsignedIntTy;
       size = ast_ctx.getIntWidth(type);
       llvm::APInt val(size, z3_expr.bool_value() == Z3_L_TRUE ? 1 : 0);
-      result = clang::IntegerLiteral::Create(ast_ctx, val, type,
-                                             clang::SourceLocation());
+      result = CreateIntegerLiteral(ast_ctx, val, type);
     } break;
 
     case Z3_BV_SORT: {
       llvm::APInt val(size, Z3_get_numeral_string(z3_expr.ctx(), z3_expr), 10);
-      result = clang::IntegerLiteral::Create(ast_ctx, val, type,
-                                             clang::SourceLocation());
+      result = CreateIntegerLiteral(ast_ctx, val, type);
     } break;
 
     case Z3_FLOATING_POINT_SORT: {
@@ -156,8 +154,7 @@ static clang::Expr *CreateLiteralExpr(clang::ASTContext &ast_ctx,
       }
       llvm::APInt ival(size, Z3_get_numeral_string(z3_expr.ctx(), z3_expr), 10);
       llvm::APFloat fval(*semantics, ival);
-      result = clang::FloatingLiteral::Create(ast_ctx, fval, /*isexact=*/true,
-                                              type, clang::SourceLocation());
+      result = CreateFloatingLiteral(ast_ctx, fval, type);
     } break;
 
     default:

--- a/rellic/AST/Z3ConvVisitor.cpp
+++ b/rellic/AST/Z3ConvVisitor.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#define GOOGLE_STRIP_LOG 1
+// #define GOOGLE_STRIP_LOG 1
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
@@ -168,7 +168,10 @@ static clang::Expr *CreateLiteralExpr(clang::ASTContext &ast_ctx,
 }  // namespace
 
 Z3ConvVisitor::Z3ConvVisitor(clang::ASTContext *c_ctx, z3::context *z_ctx)
-    : ast_ctx(c_ctx), z3_ctx(z_ctx), z3_expr_vec(*z3_ctx) {}
+    : ast_ctx(c_ctx),
+      z3_ctx(z_ctx),
+      z3_expr_vec(*z3_ctx),
+      z3_decl_vec(*z3_ctx) {}
 
 // Inserts a `clang::Expr` <=> `z3::expr` mapping into
 void Z3ConvVisitor::InsertZ3Expr(clang::Expr *c_expr, z3::expr z3_expr) {
@@ -185,6 +188,24 @@ z3::expr Z3ConvVisitor::GetZ3Expr(clang::Expr *c_expr) {
   auto iter = z3_expr_map.find(c_expr);
   CHECK(iter != z3_expr_map.end());
   return z3_expr_vec[iter->second];
+}
+
+// Inserts a `clang::ValueDecl` <=> `z3::func_decl` mapping into
+void Z3ConvVisitor::InsertZ3Decl(clang::ValueDecl *c_decl,
+                                 z3::func_decl z3_decl) {
+  auto iter = z3_decl_map.find(c_decl);
+  CHECK(iter == z3_decl_map.end());
+  z3_decl_map[c_decl] = z3_decl_vec.size();
+  z3_decl_vec.push_back(z3_decl);
+}
+
+// Retrieves a `z3::func_decl` corresponding to `c_decl`.
+// The `z3::func_decl` needs to be created and inserted by
+// `Z3ConvVisistor::InsertZ3Decl` first.
+z3::func_decl Z3ConvVisitor::GetZ3Decl(clang::ValueDecl *c_decl) {
+  auto iter = z3_decl_map.find(c_decl);
+  CHECK(iter != z3_decl_map.end());
+  return z3_decl_vec[iter->second];
 }
 
 // If `expr` is not boolean, returns a `z3::expr` that corresponds
@@ -213,44 +234,164 @@ clang::Expr *Z3ConvVisitor::GetCExpr(z3::expr z3_expr) {
   return c_expr_map[hash];
 }
 
-void Z3ConvVisitor::DeclareCVar(clang::ValueDecl *c_decl) {
-  auto name = c_decl->getNameAsString();
-  DLOG(INFO) << "Declaring C variable: " << name;
-  CHECK(c_decl != nullptr);
-  if (c_var_map.find(name) != c_var_map.end()) {
-    DLOG(INFO) << "Re-declaration of " << name;
-  }
-  c_var_map[name] = c_decl;
+void Z3ConvVisitor::InsertCDecl(z3::func_decl z3_decl,
+                                clang::ValueDecl *c_decl) {
+  auto id = Z3_get_func_decl_id(*z3_ctx, z3_decl);
+  auto iter = c_decl_map.find(id);
+  CHECK(iter == c_decl_map.end());
+  c_decl_map[id] = c_decl;
 }
 
-clang::ValueDecl *Z3ConvVisitor::GetCVar(std::string var_name) {
-  auto iter = c_var_map.find(var_name);
-  CHECK(iter != c_var_map.end());
-  return c_var_map[var_name];
+clang::ValueDecl *Z3ConvVisitor::GetCDecl(z3::func_decl z3_decl) {
+  auto id = Z3_get_func_decl_id(*z3_ctx, z3_decl);
+  auto iter = c_decl_map.find(id);
+  CHECK(iter != c_decl_map.end());
+  return c_decl_map[id];
 }
 
 // Retrieves or creates`z3::expr`s from `clang::Expr`.
 z3::expr Z3ConvVisitor::GetOrCreateZ3Expr(clang::Expr *c_expr) {
-  if (z3_expr_map.find(c_expr) == z3_expr_map.end()) {
+  if (!z3_expr_map.count(c_expr)) {
     TraverseStmt(c_expr);
   }
   return GetZ3Expr(c_expr);
 }
 
+z3::func_decl Z3ConvVisitor::GetOrCreateZ3Decl(clang::ValueDecl *c_decl) {
+  if (!z3_decl_map.count(c_decl)) {
+    TraverseDecl(c_decl);
+  }
+
+  auto z3_decl = GetZ3Decl(c_decl);
+
+  auto id = Z3_get_func_decl_id(*z3_ctx, z3_decl);
+  if (!c_decl_map.count(id)) {
+    InsertCDecl(z3_decl, c_decl);
+  }
+
+  return z3_decl;
+}
+
 // Retrieves or creates `clang::Expr` from `z3::expr`.
 clang::Expr *Z3ConvVisitor::GetOrCreateCExpr(z3::expr z3_expr) {
-  if (c_expr_map.find(z3_expr.hash()) == c_expr_map.end()) {
+  if (!c_expr_map.count(z3_expr.hash())) {
     VisitZ3Expr(z3_expr);
   }
   return GetCExpr(z3_expr);
 }
 
+bool Z3ConvVisitor::VisitVarDecl(clang::VarDecl *c_var) {
+  auto name = c_var->getNameAsString().c_str();
+  DLOG(INFO) << "VisitVarDecl: " << name;
+  if (z3_decl_map.count(c_var)) {
+    DLOG(INFO) << "Re-declaration of " << name << "; Returning.";
+    return true;
+  }
+
+  auto z3_sort = GetZ3Sort(*ast_ctx, *z3_ctx, c_var->getType());
+  auto z3_const = z3_ctx->constant(name, z3_sort);
+
+  InsertZ3Decl(c_var, z3_const.decl());
+
+  return true;
+}
+
+bool Z3ConvVisitor::VisitFunctionDecl(clang::FunctionDecl *c_func) {
+  LOG(FATAL) << "Unimplemented FunctionDecl visitor";
+  return true;
+}
+
+bool Z3ConvVisitor::VisitCStyleCastExpr(clang::CStyleCastExpr *cast) {
+  DLOG(INFO) << "VisitCStyleCastExpr";
+  if (z3_expr_map.find(cast) != z3_expr_map.end()) {
+    return true;
+  }
+
+  auto z3_expr = GetOrCreateZ3Expr(cast->getSubExpr());
+
+  switch (cast->getCastKind()) {
+    case clang::CastKind::CK_NullToPointer: {
+      CHECK(z3_expr.is_bv() && z3_expr.is_const() && z3_expr.is_numeral())
+          << "Pointer cast cast operand is not a bit-vector constant";
+      auto ptr_type = ast_ctx->getPointerType(cast->getType());
+      auto ptr_size = ast_ctx->getTypeSize(ptr_type);
+      z3_expr = z3::sext(z3_expr, ptr_size - z3_expr.get_sort().bv_size());
+    } break;
+
+    default:
+      LOG(FATAL) << "Unsupported cast type: " << cast->getCastKindName();
+      break;
+  }
+
+  InsertZ3Expr(cast, z3_expr);
+
+  return true;
+}
+
+bool Z3ConvVisitor::VisitArraySubscriptExpr(clang::ArraySubscriptExpr *sub) {
+  DLOG(INFO) << "VisitArraySubscriptExpr";
+  if (z3_expr_map.count(sub)) {
+    return true;
+  }
+  // Get base
+  auto c_base = sub->getBase();
+  auto z3_base = GetOrCreateZ3Expr(c_base);
+  auto base_sort = z3_base.get_sort();
+  CHECK(base_sort.is_bv()) << "Invalid Z3 sort for base expression";
+  CHECK(base_sort.bv_size() == ast_ctx->getTypeSize(c_base->getType()))
+      << "Incompatible Z3 sort and C type for base expression";
+  // Get index
+  auto z3_idx = GetOrCreateZ3Expr(sub->getIdx());
+  auto idx_sort = z3_idx.get_sort();
+  CHECK(idx_sort.is_bv()) << "Invalid Z3 sort for index expression";
+  // Get result
+  auto elm_sort = GetZ3Sort(*ast_ctx, *z3_ctx, sub->getType());
+  // Create a z3_function
+  auto z3_arr_sub = z3_ctx->function("ArraySub", base_sort, idx_sort, elm_sort);
+  // Create a z3 expression
+  InsertZ3Expr(sub, z3_arr_sub(z3_base, z3_idx));
+  // Done
+  return true;
+}
+
+bool Z3ConvVisitor::VisitMemberExpr(clang::MemberExpr *expr) {
+  DLOG(INFO) << "VisitMemberExpr";
+  if (z3_expr_map.count(expr)) {
+    return true;
+  }
+
+  auto mem = expr->getMemberDecl();
+  auto mem_sort = GetZ3Sort(*ast_ctx, *z3_ctx, mem->getType());
+
+  auto z3_base = GetOrCreateZ3Expr(expr->getBase());
+  auto base_sort = z3_base.get_sort();
+
+  auto mem_name_sort = z3_ctx->string_sort();
+  auto z3_mem_name =
+      z3_ctx->constant(mem->getNameAsString().c_str(), mem_name_sort);
+
+  auto z3_mem_expr =
+      z3_ctx->function("Member", base_sort, mem_name_sort, mem_sort);
+
+  InsertZ3Expr(expr, z3_mem_expr(z3_base, z3_mem_name));
+
+  return true;
+}
+
+bool Z3ConvVisitor::VisitCallExpr(clang::CallExpr *call) {
+  LOG(FATAL) << "Unimplemented CallExpr visitor";
+  return true;
+}
+
 // Translates clang unary operators expressions to Z3 equivalents.
 bool Z3ConvVisitor::VisitParenExpr(clang::ParenExpr *parens) {
   DLOG(INFO) << "VisitParenExpr";
-  if (z3_expr_map.find(parens) == z3_expr_map.end()) {
-    InsertZ3Expr(parens, GetOrCreateZ3Expr(parens->getSubExpr()));
+  if (z3_expr_map.count(parens)) {
+    return true;
   }
+
+  InsertZ3Expr(parens, GetOrCreateZ3Expr(parens->getSubExpr()));
+
   return true;
 }
 
@@ -258,19 +399,26 @@ bool Z3ConvVisitor::VisitParenExpr(clang::ParenExpr *parens) {
 bool Z3ConvVisitor::VisitUnaryOperator(clang::UnaryOperator *c_op) {
   DLOG(INFO) << "VisitUnaryOperator: "
              << c_op->getOpcodeStr(c_op->getOpcode()).str();
-  if (z3_expr_map.find(c_op) == z3_expr_map.end()) {
-    // Get operand
-    auto operand = GetOrCreateZ3Expr(c_op->getSubExpr());
-    // Create z3 unary op
-    switch (c_op->getOpcode()) {
-      case clang::UO_LNot:
-        InsertZ3Expr(c_op, !Z3BoolCast(operand));
-        break;
+  if (z3_expr_map.count(c_op)) {
+    return true;
+  }
+  // Get operand
+  auto operand = GetOrCreateZ3Expr(c_op->getSubExpr());
+  // Create z3 unary op
+  switch (c_op->getOpcode()) {
+    case clang::UO_LNot: {
+      InsertZ3Expr(c_op, !Z3BoolCast(operand));
+    } break;
 
-      default:
-        LOG(FATAL) << "Unknown clang::UnaryOperator operation!";
-        break;
-    }
+    case clang::UO_AddrOf: {
+      auto ptr_sort = GetZ3Sort(*ast_ctx, *z3_ctx, c_op->getType());
+      auto z3_addrof = z3_ctx->function("AddrOf", operand.get_sort(), ptr_sort);
+      InsertZ3Expr(c_op, z3_addrof(operand));
+    } break;
+
+    default:
+      LOG(FATAL) << "Unknown clang::UnaryOperator operation!";
+      break;
   }
   return true;
 }
@@ -278,36 +426,37 @@ bool Z3ConvVisitor::VisitUnaryOperator(clang::UnaryOperator *c_op) {
 // Translates clang binary operators expressions to Z3 equivalents.
 bool Z3ConvVisitor::VisitBinaryOperator(clang::BinaryOperator *c_op) {
   DLOG(INFO) << "VisitBinaryOperator: " << c_op->getOpcodeStr().str();
-  if (z3_expr_map.find(c_op) == z3_expr_map.end()) {
-    // Get operands
-    auto lhs = GetOrCreateZ3Expr(c_op->getLHS());
-    auto rhs = GetOrCreateZ3Expr(c_op->getRHS());
-    // Create z3 binary op
-    switch (c_op->getOpcode()) {
-      case clang::BO_LAnd:
-        InsertZ3Expr(c_op, Z3BoolCast(lhs) && Z3BoolCast(rhs));
-        break;
+  if (z3_expr_map.count(c_op)) {
+    return true;
+  }
+  // Get operands
+  auto lhs = GetOrCreateZ3Expr(c_op->getLHS());
+  auto rhs = GetOrCreateZ3Expr(c_op->getRHS());
+  // Create z3 binary op
+  switch (c_op->getOpcode()) {
+    case clang::BO_LAnd:
+      InsertZ3Expr(c_op, Z3BoolCast(lhs) && Z3BoolCast(rhs));
+      break;
 
-      case clang::BO_LOr:
-        InsertZ3Expr(c_op, Z3BoolCast(lhs) || Z3BoolCast(rhs));
-        break;
+    case clang::BO_LOr:
+      InsertZ3Expr(c_op, Z3BoolCast(lhs) || Z3BoolCast(rhs));
+      break;
 
-      case clang::BO_EQ:
-        InsertZ3Expr(c_op, lhs == rhs);
-        break;
+    case clang::BO_EQ: {
+      InsertZ3Expr(c_op, lhs == rhs);
+    } break;
 
-      case clang::BO_NE:
-        InsertZ3Expr(c_op, lhs != rhs);
-        break;
+    case clang::BO_NE:
+      InsertZ3Expr(c_op, lhs != rhs);
+      break;
 
-      case clang::BO_Rem:
-        InsertZ3Expr(c_op, z3::srem(lhs, rhs));
-        break;
+    case clang::BO_Rem:
+      InsertZ3Expr(c_op, z3::srem(lhs, rhs));
+      break;
 
-      default:
-        LOG(FATAL) << "Unknown clang::BinaryOperator operation!";
-        break;
-    }
+    default:
+      LOG(FATAL) << "Unknown clang::BinaryOperator operation!";
+      break;
   }
   return true;
 }
@@ -317,12 +466,14 @@ bool Z3ConvVisitor::VisitDeclRefExpr(clang::DeclRefExpr *c_ref) {
   auto ref_decl = c_ref->getDecl();
   auto ref_name = ref_decl->getNameAsString();
   DLOG(INFO) << "VisitDeclRefExpr: " << ref_name;
-  if (z3_expr_map.find(c_ref) == z3_expr_map.end()) {
-    DeclareCVar(ref_decl);
-    auto z3_sort = GetZ3Sort(*ast_ctx, *z3_ctx, c_ref->getType());
-    auto z3_const = z3_ctx->constant(ref_name.c_str(), z3_sort);
-    InsertZ3Expr(c_ref, z3_const);
+  if (z3_expr_map.count(c_ref)) {
+    return true;
   }
+  GetOrCreateZ3Decl(ref_decl);
+  auto z3_sort = GetZ3Sort(*ast_ctx, *z3_ctx, c_ref->getType());
+  auto z3_const = z3_ctx->constant(ref_name.c_str(), z3_sort);
+  InsertZ3Expr(c_ref, z3_const);
+
   return true;
 }
 
@@ -330,13 +481,14 @@ bool Z3ConvVisitor::VisitDeclRefExpr(clang::DeclRefExpr *c_ref) {
 bool Z3ConvVisitor::VisitIntegerLiteral(clang::IntegerLiteral *c_lit) {
   auto lit_val = c_lit->getValue().getLimitedValue();
   DLOG(INFO) << "VisitIntegerLiteral: " << lit_val;
-  if (z3_expr_map.find(c_lit) == z3_expr_map.end()) {
-    auto z3_sort = GetZ3Sort(*ast_ctx, *z3_ctx, c_lit->getType());
-    if (z3_sort.is_bool()) {
-      InsertZ3Expr(c_lit, z3_ctx->bool_val(lit_val != 0));
-    } else {
-      InsertZ3Expr(c_lit, z3_ctx->num_val(lit_val, z3_sort));
-    }
+  if (z3_expr_map.count(c_lit)) {
+    return true;
+  }
+  auto z3_sort = GetZ3Sort(*ast_ctx, *z3_ctx, c_lit->getType());
+  if (z3_sort.is_bool()) {
+    InsertZ3Expr(c_lit, z3_ctx->bool_val(lit_val != 0));
+  } else {
+    InsertZ3Expr(c_lit, z3_ctx->num_val(lit_val, z3_sort));
   }
   return true;
 }
@@ -387,10 +539,9 @@ void Z3ConvVisitor::VisitConstant(z3::expr z3_const) {
       c_expr = CreateLiteralExpr(*ast_ctx, z3_const);
       break;
     // Uninterpreted constants
-    case Z3_OP_UNINTERPRETED: {
-      auto name = z3_const.decl().name().str();
-      c_expr = CreateDeclRefExpr(*ast_ctx, GetCVar(name));
-    } break;
+    case Z3_OP_UNINTERPRETED:
+      c_expr = CreateDeclRefExpr(*ast_ctx, GetCDecl(z3_const.decl()));
+      break;
 
     // Unknowns
     default:
@@ -407,9 +558,8 @@ void Z3ConvVisitor::VisitUnaryApp(z3::expr z3_op) {
   // Get operand
   auto operand = GetCExpr(z3_op.arg(0));
   // Create C unary operator
-  auto kind = z3_op.decl().decl_kind();
   clang::Expr *c_op = nullptr;
-  switch (kind) {
+  switch (z3_op.decl().decl_kind()) {
     case Z3_OP_NOT:
       c_op = CreateNotExpr(*ast_ctx, operand);
       break;

--- a/rellic/AST/Z3ConvVisitor.h
+++ b/rellic/AST/Z3ConvVisitor.h
@@ -73,15 +73,16 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
   bool VisitDeclRefExpr(clang::DeclRefExpr *c_ref);
   bool VisitIntegerLiteral(clang::IntegerLiteral *c_lit);
 
-  bool VisitVarDecl(clang::VarDecl *c_var);
-  bool VisitFunctionDecl(clang::FunctionDecl *c_func);
-  
+  bool VisitVarDecl(clang::VarDecl *var);
+  bool VisitFieldDecl(clang::FieldDecl *field);
+  bool VisitFunctionDecl(clang::FunctionDecl *func);
+
   // Do not traverse function bodies
-  bool TraverseFunctionDecl(clang::FunctionDecl *c_func) {
-    WalkUpFromFunctionDecl(c_func);
+  bool TraverseFunctionDecl(clang::FunctionDecl *func) {
+    WalkUpFromFunctionDecl(func);
     return true;
   }
-  
+
   void VisitConstant(z3::expr z3_const);
   void VisitUnaryApp(z3::expr z3_op);
   void VisitBinaryApp(z3::expr z3_op);


### PR DESCRIPTION
Resolves #29

Adds initial handling of aggregate LLVM types and NULL pointer constants. This includes translation of GEP instructions with aggregate type operands to the corresponding C operations (array subscript and member access expressions).

Subsequently adds Z3 simplification and rule-based simplification of expressions with above mentioned operands.